### PR TITLE
Fix ermfish analysis tech + fix Ermcon unable to start naturally

### DIFF
--- a/SCHIZO/Creatures/Ermfish/ErmfishLoader.cs
+++ b/SCHIZO/Creatures/Ermfish/ErmfishLoader.cs
@@ -76,7 +76,7 @@ public static class ErmfishLoader
             unlockPopup = unlockSprite
         });
 
-		List<LootDistributionData.BiomeData> biomes = new();
+        List<LootDistributionData.BiomeData> biomes = new();
 		foreach (BiomeType biome in Enum.GetValues(typeof(BiomeType)).Cast<BiomeType>())
 		{
 			biomes.Add(new LootDistributionData.BiomeData { biome = biome, count = 1, probability = 0.025f });

--- a/SCHIZO/Creatures/Ermfish/ErmfishPatches.cs
+++ b/SCHIZO/Creatures/Ermfish/ErmfishPatches.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using HarmonyLib;
+using Nautilus.Handlers;
 using UnityEngine;
 
 namespace SCHIZO.Creatures.Ermfish;
@@ -103,4 +104,16 @@ public static class ErmfishPatches
 		if (!pickupable || !ErmfishLoader.ErmfishTechTypes.Contains(pickupable.GetTechType())) return;
 		ErmfishLoader.HurtSounds.Play(__instance.GetComponent<FMOD_CustomEmitter>());
 	}
+
+    [HarmonyPatch(typeof(KnownTech), nameof(KnownTech.Initialize))]
+    [HarmonyPostfix]
+    public static void FixErmfishAnalysisTech()
+    {
+        if (KnownTech.analysisTech is null) return;
+
+        KnownTech.AnalysisTech tech = KnownTech.analysisTech.FirstOrDefault(tech => tech.techType == ModItems.Ermfish);
+        if (tech is null) return;
+        tech.unlockMessage = KnownTechHandler.DefaultUnlockData.NewCreatureDiscoveredMessage;
+        tech.unlockSound = KnownTechHandler.DefaultUnlockData.NewCreatureDiscoveredSound;
+    }
 }

--- a/SCHIZO/Events/ErmCon/ErmConEvent.cs
+++ b/SCHIZO/Events/ErmCon/ErmConEvent.cs
@@ -64,7 +64,7 @@ public class ErmConEvent : CustomEvent
         // If a Queen Erm cannot be located or designated, the swarm becomes distressed, and seeks the nearest intelligent(?) being capable of designating the Queen for the swarm.
         // It is not currently known whether Ermfish swarm behaviors change if deprived of their Queen for too long.
         // Everyone who has so far been resourceful enough to survive on 4546B has displayed sufficient sensibility in choosing not to test that theory.
-        int ermsInRange = PhysicsHelpers.ObjectsInRange(CongregationTarget, SearchRadius)
+        int ermsInRange = PhysicsHelpers.ObjectsInRange(gameObject, SearchRadius)
             .OfTechType(ErmfishLoader.ErmfishTechTypes)
             .Count();
         if (ermsInRange < MinAttendance)


### PR DESCRIPTION
Nautilus made a [tiny `??=` oopsie woopsie](https://github.com/SubnauticaModding/Nautilus/blob/fdfa05bc805ba76e422d49d278e37b37ede027e5/Nautilus/Handlers/KnownTechHandler.cs#L30-L32) which ended up ignoring the sound/message we specified because of the defaults. This patch should set those after Nautilus does its thing.

I also made a [tiny oopsie woopsie](https://github.com/Alexejhero/Vedal-Subnautica-Mod/blob/bf8b4011d8d74c65dbbb8048f37f8f39f8759898/SCHIZO/Events/ErmCon/ErmConEvent.cs#L67) that made ErmCon effectively be unable to start automatically thanks to a NullRef.