### PR TITLE
Fix Cyclops with aquarium destroying itself

### DIFF
--- a/SCHIZO/Patches/FixAquariumCollisionsPatch.cs
+++ b/SCHIZO/Patches/FixAquariumCollisionsPatch.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace SCHIZO.Patches;
+
+[HarmonyPatch]
+public static class FixAquariumCollisionsPatch
+{
+    [HarmonyPatch(typeof(DealDamageOnImpact), nameof(DealDamageOnImpact.OnCollisionEnter))]
+    [HarmonyPrefix]
+    public static bool FixAquariumCollisionDamage(DealDamageOnImpact __instance, Collision collision)
+        => __instance.gameObject.GetComponent<SubRoot>() && !collision.gameObject.GetComponent<Aquarium>();
+
+    [HarmonyPatch(typeof(SubRoot), nameof(SubRoot.OnCollisionEnter))]
+    [HarmonyPrefix]
+    public static bool FixAquariumCollisionSound(SubRoot __instance, Collision col) => !col.gameObject.GetComponent<Aquarium>();
+}


### PR DESCRIPTION
Aquarium collides with cyclops for some reason and that makes the cyclops implode (aquarium belongs to cyclops ∴ damage source is itself)

More of a workaround than a fix but I honestly cba to find the actual root cause, it's probably something stupid we did that only breaks in this one place in the whole game and is not worth the effort