### PR TITLE
Add GitHub Action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+﻿name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [BelowZero, Subnautica]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0
+
+    - name: Build mod
+      run: dotnet build SCHIZO/SCHIZO.csproj -c ${{ matrix.configuration }}
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: SCHIZO-${{ matrix.configuration }}.dll
+        path: SCHIZO/bin/${{ matrix.configuration }}/net472/SCHIZO.dll

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -26,15 +26,14 @@ jobs:
     - name: Create release archive
       run: |
           cd Install/${{ matrix.configuration }}
-          zip -r9 ../mod-and-deps-${{ matrix.configuration }}.zip *
-          cd BepInEx/plugins
-          zip -r9 ../../../mod-only-${{ matrix.configuration }}.zip SCHIZO
-          cd ../../../Common
-          zip -r9 ../mod-and-deps-${{ matrix.configuration }}.zip *
+          cp BepInEx/plugins/SCHIZO/SCHIZO.dll ../SCHIZO-${{ matrix.configuration }}.dll
+          zip -r9 ../SCHIZO-${{ matrix.configuration }}-with-dependencies.zip *
+          cd ../Common
+          zip -r9 ../SCHIZO-${{ matrix.configuration }}-with-dependencies.zip *
 
     - name: Update the release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          Install/mod-and-deps-${{ matrix.configuration }}.zip
-          Install/mod-only-${{ matrix.configuration }}.zip
+          Install/SCHIZO-${{ matrix.configuration }}-with-dependencies.zip
+          Install/SCHIZO-${{ matrix.configuration }}.dll

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -21,17 +21,17 @@ jobs:
       with:
         workflow: build.yml
         name: SCHIZO-${{ matrix.configuration }}.dll
-        path: Install/BelowZero/BepInEx/plugins/SCHIZO/SCHIZO.dll.extracted
+        path: Install/${{ matrix.configuration }}/BepInEx/plugins/SCHIZO/SCHIZO.dll.extracted
 
     - name: Clean extracted artifact
       run: |
-        cd Install/BelowZero/BepInEx/plugins/SCHIZO
+        cd Install/${{ matrix.configuration }}/BepInEx/plugins/SCHIZO
         mv SCHIZO.dll.extracted/SCHIZO.dll SCHIZO.dll
         rm -rf SCHIZO.dll.extracted
 
     - name: Create release archive
       run: |
-          cd Install/BelowZero
+          cd Install/${{ matrix.configuration }}
           zip -r9 ../release-${{ matrix.configuration }}.zip *
           cd ../Common
           zip -r9 ../release-${{ matrix.configuration }}.zip *

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -16,27 +16,25 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Get BZ artifact from build
+    - name: Get artifact from build
       uses: dawidd6/action-download-artifact@v2
       with:
         workflow: build.yml
         name: SCHIZO-${{ matrix.configuration }}.dll
-        path: Install/${{ matrix.configuration }}/BepInEx/plugins/SCHIZO/SCHIZO.dll.extracted
-
-    - name: Clean extracted artifact
-      run: |
-        cd Install/${{ matrix.configuration }}/BepInEx/plugins/SCHIZO
-        mv SCHIZO.dll.extracted/SCHIZO.dll SCHIZO.dll
-        rm -rf SCHIZO.dll.extracted
+        path: Install/${{ matrix.configuration }}/BepInEx/plugins/SCHIZO/
 
     - name: Create release archive
       run: |
           cd Install/${{ matrix.configuration }}
-          zip -r9 ../release-${{ matrix.configuration }}.zip *
-          cd ../Common
-          zip -r9 ../release-${{ matrix.configuration }}.zip *
+          zip -r9 ../mod-and-deps-${{ matrix.configuration }}.zip *
+          cd BepInEx/plugins
+          zip -r9 ../../../mod-only-${{ matrix.configuration }}.zip SCHIZO
+          cd ../../../Common
+          zip -r9 ../mod-and-deps-${{ matrix.configuration }}.zip *
 
     - name: Update the release
       uses: softprops/action-gh-release@v1
       with:
-        files: Install/release-${{ matrix.configuration }}.zip
+        files: |
+          Install/mod-and-deps-${{ matrix.configuration }}.zip
+          Install/mod-only-${{ matrix.configuration }}.zip

--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -1,0 +1,42 @@
+﻿name: Create and publish package
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  package-release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        configuration: [BelowZero, Subnautica]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get BZ artifact from build
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: build.yml
+        name: SCHIZO-${{ matrix.configuration }}.dll
+        path: Install/BelowZero/BepInEx/plugins/SCHIZO/SCHIZO.dll.extracted
+
+    - name: Clean extracted artifact
+      run: |
+        cd Install/BelowZero/BepInEx/plugins/SCHIZO
+        mv SCHIZO.dll.extracted/SCHIZO.dll SCHIZO.dll
+        rm -rf SCHIZO.dll.extracted
+
+    - name: Create release archive
+      run: |
+          cd Install/BelowZero
+          zip -r9 ../release-${{ matrix.configuration }}.zip *
+          cd ../Common
+          zip -r9 ../release-${{ matrix.configuration }}.zip *
+
+    - name: Update the release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: Install/release-${{ matrix.configuration }}.zip


### PR DESCRIPTION
This does the following things:

- All commits to main & PRs to main: Builds both Subnautica and BZ dlls, and uploads them as artifacts
- On release creation: Packages the builds into `.zip` archives and uploads them to the release

Will need someone to test the archives to make sure they work: https://github.com/jameshi16/Neurosama-Subnautica-Mod/releases/tag/1.5.0

Example of a PR build failing: https://github.com/jameshi16/Neurosama-Subnautica-Mod/pull/1

Have tested the standard Subnautica mod with a mate's computer, it looks like it functions.